### PR TITLE
Bug fix: Banana Navigation - Deep Q Network

### DIFF
--- a/Banana_Navigation-Deep_Q_Networks/Navigation.ipynb
+++ b/Banana_Navigation-Deep_Q_Networks/Navigation.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,32 +46,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:unityagents:\n",
-      "'Academy' started successfully!\n",
-      "Unity Academy name: Academy\n",
-      "        Number of Brains: 1\n",
-      "        Number of External Brains : 1\n",
-      "        Lesson number : 0\n",
-      "        Reset Parameters :\n",
-      "\t\t\n",
-      "Unity brain name: BananaBrain\n",
-      "        Number of Visual Observations (per agent): 0\n",
-      "        Vector Observation space type: continuous\n",
-      "        Vector Observation space size (per agent): 37\n",
-      "        Number of stacked Vector Observation: 1\n",
-      "        Vector Action space type: discrete\n",
-      "        Vector Action space size (per agent): 4\n",
-      "        Vector Action descriptions: , , , \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "env = UnityEnvironment(file_name=r\"C:\\University_Work\\DRL\\deep-reinforcement-learning\\p1_navigation\\Banana_Windows_x86_64\\Banana.exe\")"
    ]
@@ -85,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,26 +90,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of agents: 1\n",
-      "Number of actions: 4\n",
-      "States look like: [1.         0.         0.         0.         0.84408134 0.\n",
-      " 0.         1.         0.         0.0748472  0.         1.\n",
-      " 0.         0.         0.25755    1.         0.         0.\n",
-      " 0.         0.74177343 0.         1.         0.         0.\n",
-      " 0.25854847 0.         0.         1.         0.         0.09355672\n",
-      " 0.         1.         0.         0.         0.31969345 0.\n",
-      " 0.        ]\n",
-      "States have length: 37\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# reset the environment\n",
     "env_info = env.reset(train_mode=True)[brain_name]\n",
@@ -180,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -207,25 +167,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "outputs": [],
    "source": [
     "buffer_size = 10000         # Size of memory buffer\n",
     "batch_size = 128            # Number of experiences to sample during learning\n",
     "alpha = 0.005               # Learning rate\n",
-    "gamma = 0.99                # Discount parameter\n",
+    "gamma = 0.999               # Discount parameter\n",
     "tau = 0.001                 # Interpolation parameter\n",
     "local_update_every = 1      # Number of actions to take before updating local net weights\n",
-    "target_update_every = 4     # Number of actions to take before updating target net weights\n",
+    "target_update_every = 8     # Number of actions to take before updating target net weights\n",
     "fc1_units = 64              # Number of nodes in layer 1 of neural network\n",
     "fc2_units = 64              # Number of nodes in layer 2 of neural network\n",
     "seed = 0\n",
     "a = 1                       # Sampling probability (0=random | 1=priority)\n",
-    "b = 1                       # Influence of importance sampling weights over learning\n",
+    "b = 0.3                     # Influence of importance sampling weights over learning\n",
+    "b_increase = 0.001          # Amount to increase b by every learning step\n",
+    "b_end = 1\n",
     "\n",
-    "dbl_dqn = False             # Double Q Learning\n",
-    "priority_rpl = False        # Prioritised Experience Replay\n",
-    "duel_dqn = False            # Duelling Q Networks"
+    "dbl_dqn = True              # Double Q Learning\n",
+    "priority_rpl = True         # Prioritised Experience Replay\n",
+    "duel_dqn = True             # Duelling Q Networks"
    ],
    "metadata": {
     "collapsed": false,
@@ -236,60 +198,23 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "agent = Agent(state_size, action_size, fc1_units, fc2_units, buffer_size, batch_size, alpha, gamma, tau,\n",
-    "              local_update_every, target_update_every, seed, a, b, dbl_dqn, priority_rpl, duel_dqn)"
+    "              local_update_every, target_update_every, seed, a, b, b_increase, b_end, dbl_dqn, priority_rpl, duel_dqn)"
    ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   },
-   "execution_count": 7,
-   "outputs": []
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Episode 100\tAverage Score: 0.09\n",
-      "Episode 200\tAverage Score: -0.03\n",
-      "Episode 300\tAverage Score: -0.21\n",
-      "Episode 400\tAverage Score: -0.24\n",
-      "Episode 500\tAverage Score: 0.062\n",
-      "Episode 600\tAverage Score: -0.01\n",
-      "Episode 700\tAverage Score: -0.12\n",
-      "Episode 800\tAverage Score: 0.071\n",
-      "Episode 900\tAverage Score: 0.17\n",
-      "Episode 1000\tAverage Score: -0.15\n",
-      "Episode 1100\tAverage Score: 0.013\n",
-      "Episode 1200\tAverage Score: -0.08\n",
-      "Episode 1300\tAverage Score: -0.03\n",
-      "Episode 1400\tAverage Score: 0.232\n",
-      "Episode 1500\tAverage Score: 0.37\n",
-      "Episode 1600\tAverage Score: -0.04\n",
-      "Episode 1700\tAverage Score: 0.342\n",
-      "Episode 1800\tAverage Score: -0.16\n",
-      "Episode 1900\tAverage Score: -0.12\n",
-      "Episode 2000\tAverage Score: 0.272\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "<Figure size 432x288 with 1 Axes>",
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEGCAYAAABsLkJ6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAA6MklEQVR4nO2dd3wWVdbHfycJndBDQguh19AMoIIVRAQVxFVUFNT1xd5218ruq7vuruiuffVV7BV17SsrdgELvfdm6CW0UAKBJPf9Y0qeMjPPzDzTnmfO9/PhQ54p95657dx7bjkkhADDMAwTPjL8FoBhGIbxB1YADMMwIYUVAMMwTEhhBcAwDBNSWAEwDMOElCy/BbBCs2bNREFBgd9iMAzDpBQLFizYI4TIib2eUgqgoKAA8+fP91sMhmGYlIKINmldZxMQwzBMSGEFwDAME1JYATAMw4QUVgAMwzAhhRUAwzBMSGEFwDAME1JYATAMw4QUVgAh4D9LtqP06Am/xUhJFm85gOXbSv0WwxalZSfwnyXb/RYjii9X7ETJoXJP4/xhzW5s2VfmaZypAiuANOfXPUdw69RFuPO9xX6LkpKMfvYnnP/Mj36LYYs73luEW6cuwq97jvgtCgDg6PFKXP/mAlz18hxP47361XkY+vgMT+NMFVgBpDlHj1cCALYfOOqzJIzXbD9wDABw7ESlz5JIVMrOp/zojZdXVHkeZyrACiDNIfJbAoZhggorAIZJc4LSCWD3s8GDFQDDpDnc7jJ6sAJgmDQlKD1/JriwAggJ3AtkggKxZgoMrADSHK5rDMPowQqAYdIcHv0xerACCAkC3AowDBMNK4A0h8A2IIZhtGEFwDAME1JYATBMmsPmP0YPVgAhgScCGb/hIhg8WAGkObwMlAnaPFCwpAk3visAIsokokVE9LnfsjBMOsImIEYP3xUAgNsBrPJbCIZJN4K245bNkMHDVwVARK0BjATwkp9y+EnJoXJ8unib6/GkQt3bfeiYJ2nx654j+HbVLt372w8cxX+X7dC89/78Lba8q83ZuBfLtpbicHkF3p272dTJmBWVVXjzl2JUVEafZf/Rwq3Ye9hbr1qxxKahlkzfr9mN9bsPAwA27y3D1yvj03z97kP4Yc3upOX5asVObNob7/jm86XmPaJ9ungbdh+SfChMW7oDO0qPYv+R4/hwwVZLsggh8M6czSg7XmHq+ch0imXOxr343XuLUVXlTg3OciVU8zwJ4G4A2XoPENFEABMBID8/3xupPOSa1+Zi+baDOL1TDhrXq+l4+MHqAxpzzavzsGL7QZzROQeN6jqfFgpn/fMHAEDx5JGa98c89zN2HjwWd3/F9lLc/cFSfLNyF6aML7IU59gps6Ww+7bCR4u2oX1OfQxo18TwnTdnb8Kf/7MS5RVVuO609gCAbQeO4nfvL8GAdk3w/vWnWJLBSSLTUE+ma16dpz4z7MkZOHYi3inL0Mdnqs8kw8Q3FyArg7D+7yPUaxWVVbjlnUWm3t9/5Dhuf3cxerRsgM9vHYyb31mIVo3qoEPz+pi5tgR98xuhfU59U2H9sLYE93+8DCt3lOKvowsTPh+ZTrEo5ebUjs3wm5Nam4rfCr6NAIjofAC7hRALjJ4TQkwRQhQJIYpycnI8ks47dpZKPY4TVeyxSPFaVulSb8csOw8e07yuNGAlSfS+lXePmvDSpYw0DkaMOI7Lnq1268iohdumFzMyaTX+TlMRU26sfLbyrlIfAUnZKt9kRf6ycilv9x05bkECYw4fc8ent58moEEALiSiYgDvAjibiN7yUR6fkPvoqWCj8Yig2a7dwIsvTP9UdActhZmuE+m+KQAhxH1CiNZCiAIAlwH4TghxpV/ypDvsjSk94Hx0F6LqvhhR+ndGgrAKiHGRNC+/rhLkxjbdG6ag4XdRcCu//Z4EBgAIIX4A8IPPYvgCsQVIJQxp4HdDwiQmUvGnu5rlEUBISKV2J90rHWBuZKbs4E2lvEt1IhU0IaKDlqaZwAqAYXQIYqUPoEiBxW7+Rb5WPUJPz5RnBeAzSkcwiI2N14QhDbxsSHiaIHnUUVialk1WAD7jfiVNvVYgKA2Xm3XezAFtQUkHx/Hou6wo28i0jjIDpfkcHSsAhklB0lU3BAkiihih+6sC3OoMsAIICK6bBtK1C+MiblT6dDUlBBH7cwDxQ4B0zTZWAD7jto0xlcwIfveyvMTLfAlRsjpOus/RsQJgAkfQHJj4TWTjk64NUZCUv9YcQLrCCiAkBKd6pQ5+p5lh25NmDZPfBwBqEZ3EPs8BuBQuKwCfSfdVBlYIQxp42dFNpd5rANt/AGwCYlwmheqoZwRl042bld7LfA9KehpRlURi65mPbE8CR5mAeBI47Zi+fEecB561uw7hqxU7AQDfr96NFdtLLYf7yaJt2Lq/zNSz63cfwj+/XIPtpebOdd935DjembPZkjw7S4/ho4WSNyMzNtZ1uw5h+vKdWLPzUJT3pqoqgVd+/BVHjyc+w94uS7YcwKFj5jwoRbJlX5muF7FZ60qwZMsBAMCqHQfx7apdUZ6VXv7xVxwzcS4/AKzcfhDfr5Y8Vy3afMDwvcoqgZd//BXlFfHP/LJxr+57ny7ehgc+XR4XtoDArHUl+HrlLvx7/hZT8kby+s+bdPO/vKISL87cqP47FHPu/JZ9ZbjypTnYffAYVu04iG9ivHqN+tePahkr3luGn9bviYtD8RcQybzifZgdkRbJKFu9d9+dZ62+APG7gBVFXXKoHO/N24z3523B/OJ9pjyNVVXBsN7sOVyOd+fqy/jjuuq0nLkuPl2dIBCHwXnNDW8tBBDtgWfYE9Weia55Td9Djx6VVQJ3vLcYeQ1qY/b9QxI+r3hCUkjUQN/+7iLMWrcHRQWN0TlX14FaFONfmYO1u7RdzWlxzhPRMinfP23ZDvzl85XYfuAo/nh+d9PhWWHUsz+pf1tpDM5/5keUHj2BUX1axd276uW5AKTvOO+pWQCA58b1U+8/9PlKlBwqx73nddUMO7LnPOLpWVH3Hv96Le4f0U3zvQ8XbMVDn69Eadlx/G5YF9Pfcvu7iwEA9Wpl4e7h0TIp32KHDxduxUV9W2Fwp2Zx9577fgOe+nad+nvljoN4Ymwf9fdpj34PALj29XlYvu0ggOh6sWRrKZZsre4sjXtpTly9mV+8L+o3Abjk+V+iriU1AtC4tmVfGf78n5U2w4s4DE7WADe9vTDuufN7tTQMZ/qKnZi+Yie27C/DAxf0iLt/89sLMefXfRpvSlz58hz1by13mk4QyhGAGygNuOJT1Gn2Hpa8C2n1pvTYfcgZv7GKb1M7vnDdxqpMR8qjRxl2v6m0TP+9Q3IcB41GNAY2oIMOeX+KXE2lN2KJ/f4DZdperEqSKEuxnrqcRqvzdLzSGQ9kTqxI0ytje3z26wywAnCMaicS9gpMog6QnzZIr0+l9PZb9WPza+IviBOObk/SJhO81rtWa6HuUlsHJmv0lEgQfDqwAnAIpdC4laVKL8dKmXFMFv/LqWsEsbE1g9Us0Ss3ZtffJ7NO30yZdXofgBONKzm0I0VvEj4I1YoVgEN4tdLCSpGMrAROSJeqjaURrq70sVnDI10SAs7IqKsAEvxWCOoyTcCZ9Imsv1rHQacrrAAcQh0BpGGB8fqTvNwV6obiNiN/UHY7m01qt/MkOROQe7I5kU/6JqCkg04aVgCMaVJhPblV3F3r7858kJPE5qmexOk+AohMhiiXkAFopN2EFYBDVM8BuFvp7c4BJFNJvJ6s8rKtMYornUxeeuUy9hv1TUBJzAHExK1VnpxOa0dKLLmrAIIwCmQF4BDp2DuOIw0+Mc7m7cSRwTaIbViiTSzOJLSpyVeTYVUFeAjgzByA9t9BaKTdhBWAQ6iF0PbEX3ArmPdzAHbesZd+Ru95mSdaYhiNvJwalZlNN9fb/2R2AjuQT26euKqXVUEwL7ECcAjX60cA9EMARHCcoHxTVA/UyzkAk3ElYwLyAycaV0oQTpCOsLYLKwCHUNfpuxyPpTkAh4QJQk8lEfYP/nJxBYmFdDMeiTiA7j4Ac6+73dYl04t3ehmoWVHSoP1nBeAUyZaFIFcwNQyPSryrpheTk56AcZ7YvacQ2x67MQIwo3/MpnWQRwBOShZbxo1MbcFNEfOwAnAIt/cB+DlHkBIjALvvuboM1DxBP3ai0u19AMnMATggW9QcQORhcC7Gy0dBpBNu9+BtLTN1toB51ka5OQkcu/rGphhO193onahmNpJZQ+95s0md3DJiE+HbD17nLCAHNnAlWAbKI4AkIKI2RPQ9Ea0kohVEdLtfsjhBlToHYHMfgMnn7M4BJFWBXXZc7ymxJiDbq4eMojDRgMdkpNt+f/V6m17kqevmTc0VVBbD0AnPKJhkzWL+9//99QdQAeD3QoiFRJQNYAERfS2EsHeIt8+oq0DtLgMNcOvq9UjVTkrYNgEZ3fPySAq/TEAe9GPjdhtrlKek0tpNM57RHIC9QWdE2NblcRrfFIAQYgeAHfLfh4hoFYBWAFxTAH/5z0q8ObtY/V1ZJTBl5kaMP6Wtem3h5v267x8pr8Abv2zCKR2aYmfpMQzvmYdlW0sxa30JTu+UAwAok73/fLFsB05UCVzYu9ppRFWVwF0fLI3zuqTHjtKj+HbVblx5ctuoMl685wjmFu/DpUVtdN/dWHJY8wz3aUt3oKBZXWwsOYJOufXRNa+BbhgTXpmLGWtL1N+fLdmO24d2wrerdqH8RBXG9m+D8ooq/LxhDy7u1xpTZm3ENae2Q52amQCAGWtLUKdGJga0a6KGsXxbKTbvK8OIwha68T717ToUtmqIwR2boU2TurrPRfLMd+uxdOsB3D+iW5zDnCkzN6h/P/R5TPGSE3b97kNYtq0UF/VtbSo+hb2Hy/Hs9xvQKbc+Lh+QDyEkb2AAsGDzfny/eje2lx7VfFcpTyMK8/Cd7G1MEWnbgaP4x5drAAAvzNgQ9+663Yfxjy9Xo3ZWJm4+qyO+WL4TjevWwModB/Hbwe1QWSWiHLX8/v3FePDCHnhx5kbkZNdCr9aNcElRa3y0MNqb2g9rSvB/P2zAv+dvQdum2mmfqPzuPnQM782t9lwW21Ae0PGlUHKoHNOWbsd5hS0w8c0FuOSk1mjfrB5O7VjtyObVn37FhpLDGFuUj837ytCrdUPVaQ0APPDpcrRpUhd/nbYqLvzXfy7GhFMLAEg+Ll6e9Ss+W7IdT4ztgx/WSOm/v+wE9kf4RDBqo79csRNfrdiFw+UVeHJsH3ywYCsKmtWLK2MfLdqGG87sgA459QEAb87ehK9W7MSK7Qejniu4dxq6tWiAz28djMwMb7RDIDyCEVEBgL4A5mjcmwhgIgDk5+cnFc8rP/0a9Xvash14ZPpq7DpY7cRlzHM/677/6PTVeP2XTerv4skjccvUhdi0t0ytrAo3yh6EIhXA16t24UPZfZ4Zrn5lHtbsOoRze+Sp1wiS96zSoycMFcDwJ2dpXr/5nWjPRkZezyIbf4Uhj81Q//5hbQk27S1THVs8On0NSo+ewH3nSZ6yJrxS7ZFL4fxnfkwYr+L6snXjOvjxnrN1n4vkadmr1Q9rSuLC/vt/V6t/H4pxCKP0ThUPbVYVwJ3vL8FMOZ1G92mFlTtKseuglB6LNh9Qvctp8cj01Xjjl014ZPrquHvjXpyt/q23CevZ7yXF0CUvOypfe7dphLqyElbYc/g4bnlnkfr7m1W78fjXa3XlAoCNe45o3k/kaeumtxZi/qbqjpSZjrIAcMs7koesf361FofLK1R3nkp+lh49ocb91mxtV4qR9TOWBz5bgdM756Bds3p4dPoavPZzMYDqMqlw70fLAMjHQRu0w4oHNwAY9Mh3aucvlsoqgXOfmIn1fx+Bisoq/OmT5bphrtpxEJ8v3a7p4c4NfJ8EJqL6AD4EcIcQ4mDsfSHEFCFEkRCiKCcnx9G4FS9JZn3RxjYeALBpr+QD2Mxw0MiPrNbrSk8k1tZoxouVUx6RjDhQdhz7jkiNneL39LANv7567D+i7Z3KSYxt+YnvReaFgEC5SY9tRPrlTgjJB7RZYuM8XlHlqkkpUR7vj/EqZta8o6TlYY16ZiUcIyrkemFU5w9G1S9zPXG9xl+NV9biZr7ArJ9qJ/BVARBRDUiN/9tCiI88j9/j+KyuHU90HryVCuFGgyBQbSNV/nfyyAAvlsk5PpGXpF1YvZ/EtwdtT4mpEYCpvRMBMJoniZnv9PLYJT9XARGAlwGsEkI87pccgHdr7K3GU+2KUWg29kE6n6taWQVIKBMkvaEriTZJf2mmSCpcv8+Vsqu8Er7nxPEOSjk1tVLLn4laL6uQnyOAQQCuAnA2ES2W/43wUoAgbMSoJj7XtUYA0Us7/W9s43a0OjkCcC4oXZxMwaD0UANQLKIxIY+AMDEqckQaS/iRo17uuvZzFdCPCMZSWM+wbAJS7uk8F6R6rsga5CMDtDAUN8nRQUIMdmclUzH8zoH4Yy7MSZSogfejaLm54U//Ge/wfRI4EHiU4skcWKb1ahAb2+BJlIhoia2OqoLYgwnCyDASU+IIE42tk59leq4mvW1AoVYAnk8CW7ynmKiEqH5AbzTgF2qlVSeBU8sGFCtu5LyKUW9NczOTQy1U5OS63feDhJkiIQBkJPhmr+c2Eh0HbQeeBA4xhkf+msx0t48MsITGlnnfZbJIrLhmFVj14X8Udc3s5xMZuWlMLhGFEK7mQ6Kw47ydmQw34QAgDUxAZvByZM8KIEmcKiBavRutSWCrh4Z5hSJrEM1SRsQ2tsnI76TxKKk5ABGssmFGoQlp2GP8jCOyWHveaROQqdEQjwC8JZn0tnTkr9WwI5asac8BWIjbpVIVW0FSrP2PS1cvR1h67V2y0fqdB3FlwvR7xjhy7HPM/wnxYwrAw7hCrQAccRvnmG9WjbA1TuGM/js4ra0iq5MjAE+WgcbNAdjvxzuZH8ntA/BfCVjFzN4HJz7JSv4SOT8FbGoVEJuAUgdLBcTqMlB1BKD9nN91XCt+v2WySvwcgP696Pfi71pteHVXgSaZiHqrxpwiUdhxcwCmV9wkiNeBj6qyeEKK03uF2AQUQJLRuJb8vhpUHc05AOVehHxRcwAWCrNrZUoWMnV3AkfLW2lxCYZTPhc0Qrb9pqSIgpQP5uYAEjW2Tqg1ZQTgV/qYWxHLIwBP0OphWw7DQkW1PAEVtcJEq8fpfyWP/XqrPSzDsD1YghGbrFHK1kSGubFO3MR8qPH7/heLKAI1AlAUgIl4yIRMbsDLQD3CkcpraQRgcM/IPKTzXJDOAlJwUil5sQQvVt6k0jQw+RGErkE15nq93uwEtpq/zu8DSCwALwNNIdxsoxKtrQ/SML/6KAhfxbCM7Ulg5bFIE5ClZtfAHCgSn4tjGLII1ijA/AjAOxOQWZyfBDbxjId5R0FqRBJRVFQk5s+fb/m9HaVHcdvURZhXvD/q+qCOTfHT+r26713Wvw2mr9iJA2Un8MnNgzD62Z+i7t92dkc8/d36uPceGtUDf/p0BQCgeXYtjChsgc652ZgycwOKZf8BsXRqXh9dWzRAWXkFvl29G7VrZODYCWN7ypUn5+PBC3rgsyXb8cCnK3DjWR1w+FgF6tTIxGMxzj5yG9RCYauG+GbV7qjrXfOykZlBOFB2AtsOaHuu0qNuzUz1HPTJYwpVRxq5DWrh4TGFuPa1+WoadMnLxk1ndsTlsqOTh8cUIjOD0L5ZPXy4cCumRniQiuRfV/TFpr1lqJWVgZPbN8WJyips2X8UL8zYgAt6t8TkL+KdqXTJzcaaXYdMf8eAgiaYW7wPAPCP3/TCXR8sBQCMLGyBact2mA7n8gH5mDpX21FJLLWyMnR9B1iVP5Zm9WvhmkEFcU6KgsyYfq3ivJMpvDi+CPd/vAxtm9SNcjRjh98Obodh3XMxdsrsxA+7QI1MwolK4za3ZlYGjmuUjV8fHpHMSasLhBBFcdfDoADOf2YWlm+L8zWTFjx6cS/c/eFSv8XAIxcX4p4Pl/ktRlpQp0YmjnroFIRJDd6//pQo96pW0FMAoTABHTzqnJeqoHHCyVnXJAjKUcjpwAkPvLkxqYcb5SIUCiCdSXSAlmcERIx0INWO02C8wY1iwQogxcnghjftSLWJdMYb3FjbxQogxQmK6SUYUjBM+sIjACaOoFiAGIZxFzcGhqFQAMHaFuMsQZkDCJZ/ZYZJP9xYsRkKBZDOZAQkB3nikmHchU1ANgmKndwNgjICSKX9JAyTivAkMBNYuP1nGHfhEQATR1BGALx0kWHchRWATdJ5Ejgg7X9apzHDBAFeBcTEwSMAhgkHbiy0YAWQ4gRmJzBPAjBMyhEKBZDOq4CCsv6eRwAM4y5pNwdARMOJaA0RrSeie/2UJVUJigmIl4EyjNv4aAIiojpE1MWpiIkoE8CzAM4D0B3A5UTU3anww0Iwmn8eATCM2/g2AiCiCwAsBjBd/t2HiD5LMu4BANYLITYKIY4DeBfAqCTD1CSdV6hc94Z1Bzlu8JfPV/otAsOkNX6uAnoQUoN9AACEEIsBtEsy7lYAIv0AbpWvRUFEE4loPhHNLykpsRVRTv1a9iRkGIYJCHVqZDoeplkFcEIIURpzzZNutRBiihCiSAhRlJOTYyuMO8/p7LBU6cXNZ3XAHUM7+S2GJsWTR/otAmOCbi0a+C2Cil6Z8aqMd2pe35Vw7bqDNCLL5HMriOgKAJlE1AnAbQB+TjLubQDaRPxuLV9znMyATJQGGZ7DZdKdGpnerHlxq7lxI1yzKXIrgB4AygG8A6AUwB1Jxj0PQCciakdENQFcBiDZeQVNgrJUMshw+8+kO5kebZpxa9m5G+EmHAHIq3WmCSHOAjDJqYiFEBVEdAuALwFkAnhFCLHCqfAjCcxmqSDDQwAmzclK8YbAjX5sQgUghKgkoioiaqgxD5AUQoj/Avivk2FqkZHiGc8wTPJ4NgJIoebG7BzAYQDLiOhrAEeUi0KI21yRymG4/U8M9/+ZdMerEYBbg2lfRgAyH8n/UhKeA0gMW4CYdCfLo0lgt7zjubHr35QCEEK8Lk/UKusp1wghTjgujUvwKiCGcZdUqGFejQDcUgBuSG9KARDRmQBeB1Asy9GGiCYIIWa6IJPjBOW8nCCTzrulGQYAsjI9MgG5FK4blgyzJqDHAAwTQqyRBekMYCqAkxyXyAW4/U8Mm4CYdCczwxsTkGtzAC6EaTZFaiiNPwAIIdYCqOGCPK7AI4DEcPvPpDveTQK7ZALycRJ4PhG9BOAt+fc4AME4hcwEHin+lIV7/0yypEIR8qoj6NbJuH6agG4EcDOkIyAAYBaA5xyXxiV4BJCYdFMCROn3TUEmFfxBeLUPwK1JYDcwqwCyADwlhHgcUHcHp8wRm6wAjJEay9QptGbIJEJFmn1TkEmFpdYerQJNqY6H2ST5FkCdiN91AHzjvDjuwBvBTJBChdYMKdAeMR7jlZJKpc6UWQVQWwhxWPkh/13XHZGch0cAiUmdIssw9vCqFUilumRWARwhon7KDyIqAnDUHZGchxUAwzBejQBSaQ7ArAK4A8C/iWgWEc2C5L7xFtekcpjchrVweuccvHDVSTilfdO4+49e3CvuWs9W5h1c1K2ZidF9WiYloxnuOte8S+bsWlkoatvY1LMTTi1Qh62DOsanj5M0rVcz6rdROj92SW8AwEOjesTd+81JrXHLWR113314THyeJkubJnXQPNve1NfYojaJH0qSNk3qJH7IJU7v3My3uBWuP709/jBMOqxgaLfmUfea1a+FfvmNPJGjSgD/e368e/PfnNTaclh92jRyQCJ9DBUAEfUnojwhxDwAXQG8B+AEJN/Av7oqmYPUysrEG9cOwLk98jB14snq9eLJI1E8eSQu7R9fOT+/9TS0b1ZP/T1uYL6up6FxA/Px5GV90TUvW732zOV9UTx5JPIa1I569t2I+K3wwQ2n4OJ+2gUot0F8o9QlLxsf3HiqKY9azbOrZezUXPqGWlkZuu+e2UXfM9v0O07D29cN1L2f37Taclg8eSQuH5Cv/u7ZqkFUnBfLFeaqUwrUvFL45yW98Ydzu6jXlX9KHnRvIYV1cvt4L0oX9W2F4skjcZbBd2jx0Y2DMHfSUKz563BTzzetVxMtG0ppe91p8R5UO+fWR28HKni9mpkonjwSs+4+O+7exr+PMHx3YLsmGKjjaap48kjccEYHkzJk4epTC0w9a4ULereMyne9MlkzMwP3jeiGW86WvH69NKE/iiePRJdcqTy8dd0AZNd2d+tSCzmvhRC4dnC7uDJ7dtfmeq+qZfLWs6M7Nfee1xWAO97AgMQjgBcAHJf/PgXA/QCeBbAfwBRXJEpBrIz4ktmMojeCdcJRhPINirnMaLRsZFITwtjWanzP20k6q6ZBJeusyKkUDb9WySQbrdniSmBTq/L9dixAeinntjUp0TLQTCHEPvnvsQCmCCE+BPAhES12VbI0JRnfBHpvOrHKSSlnSlh2K3NVAg1g1BC60X4YVSCrjbIZ5RgdfqRi1bgP9zcrJPpGAePyY7YcEAV7tZ0TyZxob4mSVMnMAegloVtJm2gEkElEipIYAuC7iHtm9xCkPVZ6eUltR9cbATjQciplVgnKbojJVDSv2w+rWWFdKZJ6yF6q9o7NKzsK5NJbJ2VKFJQ6ArDzvk9pl6gRnwpgBhHtgbTqZxYAEFFHSH6BmQTEFsBkGgIrpger0cQ2VIY9daNwhLGcxpXA+VpgpI+s5gXJ3SUrb8Wa1qLCC0KDKWB7xJbMs6kIJRgCKB2KqmTOgohJQ7dP6TVUAEKIvxHRtwBaAPhKVO9wyIDkKJ6BxTmAJI6k1euxOnHWUfUIwJqZIy4cCMN3De/Zi9IYg7yxmm5mlGMkRJGjQ+1n/F4wKCBABoYA03MAFGyfAI6YgBLcTzQCMA7bOHS3dKsZn8CzNa6tdUec1EYrj2KvJTcJrP2uZu/SZnVUgjKc6DV4P1Hnx3B04MYcgIG0VkcAimMhs28RqtND7xwav5eMJ4rf9BwA3NEATgXpRE9aSguD8pRhPAlst2PkJnxOpoNoZWJso52cCcjCdZvRKK/ZFdONCTC3sGwCsiig9Hyw5wAS5ZZpZUfereKygqNmqQRBqSYg3TpgwzTqcgeBFYADWOldZCVhr9FdBurIJHDMHIDtcBL0Kh2yN1uRJ+6a/L/dSWArYhquAgqoUojE7Ko1QkDmNFzEtAnIzjLQBIG7pVxZAXhMMvZ6vULgRsWz22MVQhgqRKNQgz4CUPcBWDCLJFoh5rcrTiHsz9nEPhfk9t8JU1ui8qLkcUqNgj2OLy2JXUJpRDIjAN1loPZDVIktskbfYnTaodAKzCTuzAEYxWdVAVg3GVWPrDTuWwrNH8z2PAkBXQbqZFgmTUC6BiDDBRB6HQR3YQXgMUm1/3qrgDQnga2htOlKj9SueSLREjjj3qa3LYhVE5Ad8arNTQFsHZG4gbGyCsiNb/R7lVQk5k1A1qVW99/omnktB2kKVgAek5lETupOAjtQOGJNEXaDrBIJet129wg4iFI/rXqIsqqgCNUKUXuBgKXgXEEIYznM7wQO4hSwtyjzJXa2AeguE+ZJ4PTCjV6ukz0vo41L5t4XprbLW71nF6PemBcjDnUOQKN5THS0gBckXAVkdgRg5eEUJVGdSLwKKDFezvMBPikAIvoHEa0moqVE9DERNfJDDqfRq+SRJHMShJViZXknsGoCSvy+kRwC5iY2NXvEHvch3W6vKGonmLtxuYWVTW9B/ERH8zjhHIDxKqAEU8h2JEoav0YAXwPoKYToBWAtgPt8ksNzkmnk9DeYOLAMNDZMg2eN7iXq/Xg+AjC450WVM1KogTCaJMgvK6eBpvkAICFOHIYXm4ZurxLzRQEIIb4SQlTIP2cDsO4pIVVJppDolAWtgle7Rqa9KGKOhLAghvq+3RGwVw2IchyHF/EpJii9qIJgAjJSRNbmAIKrATxZBprE94d5H8C1AL7Qu0lEE4loPhHNLykpcSTC58b1w21DOmneG94jD3+7qCcA4F9X9MPQbs0xpGtz3C4/f+fQznHvKJX88Ut746S2jTG0W3MM7ZYLAHj92gFRz2aQ5MADkJxAxHJap2Z4/NLe6u+sDMLIwhbo1boRGtTJwgW94z2PPTG2j/r3HUM74awuObhDQ04A+OZ3Z6B+rSxc1LcV7hzaGU9d1kf+Bul+q8Z1MKZfK7xw1UkAgEcuLowL4/IB+RjaLRf3DO8alR4jCvMwsH0TXQUxojAPfxtdiMsH5OO9iafE3f/baCmuf13RV03vWP44shseHhMvk8JTl/XFhb1bonNufQDVE3KN6lY7A/mf09oDgFoGXhpfhMsHtInLK0DyMqVFp+b14669Jzv76dW6IfIa1MYLV52EN68biLFFbVC/VhZeuboIEyPCIwKevKwPhnXPjQvrrnO74LYY5yCKcxMz5GTXUr/v5rM64Pkr+0Xdv3ZQO1zQuyUeu6Q3/jq6Z9z7k0Z0AwCM6dcK53TPVdMz0utYBgH3DO+KYd1zMaZfK0w4ta16b3iPPPz+nM646uS2UeHq5SsgOdA5rVMz1K2ZicZ19Z23PDm2D+46twtuPDOxs5onxvbBBb1bomsLKe2a1bfu0e22IZ0wvEceTu+s70BoSNfmePjiQlwxMF8tB7EMaNcEZ3XJwbDuuXj68r7q9WHdc3GHnC7jT2mLod1ycdXJbfHsFf0woF0TjCjMw0MaeeQErh3pTETfAMjTuDVJCPGp/MwkABUA3tYLRwgxBbLzmaKiIkf6SyMKW2BEYQvNe8/LDR8AdG/ZAC9N6B91//ahnXDZgDYY+Pdv497tlJuND288Nepah5z66NOmERZvOQBA6imt+Eu1R6mPF22Lev7N30retH73/hIAwPoYj06PXtwL/1myXf09uGMzdI5oGPQafqDam9LyP58bd09RYlkZhMcv7aNeH9s/H/d8uCzq2YZ1auClCUXq7ye+kY6Gem7cSdCjf0Fj9b5WA375gHwUyB7Yzu+l717zutO0G2SFLnnZUZVL+a7XrhmA0c/+BADo1kJyQ9k8u7aaJkPlRvj6M9rjhRkb1ffvG9ENL8ys/q3w9e/OQMG906KuDWzfVNNjVb/8xgCAs7vm4uyuuZgSEV7n3Gw8O64fOk2S+kC5DWph18FynNczD+1z6uPp79YDqM67yDhvPLMD/u+HDVFxKRPLn948CC0bSY31Xed2jXpGS8YzOudgxtrqDtb/yIoqu3YNvDi+KOrZYU/MwNpdh/HpzYNR2LphwrDLKyrx/vyteOTiQoztn4+nvl0X90xWBmHBn85Rf3+8aCvufG+J5uh2tNxx2lByOO77Y+mcm41nIspDrSypzzvzrrNw/VsLsGrHQUy7bTAuff4XHDleGfd+5Pfc9W+pTo4/pS3e+GVT1HPPjuuH2jUy8feL9DsnjerWxKvXVHcybpu6CAAwJSJ9G9WtGVW3AON6lSyuKQAhxFCj+0R0NYDzAQwRdhbO+khsmUwkfOT9oDrNqEpgqrBCkLLT6CgGv1FE0jIt2F2FRbC3dt5O+rhpQlNNkUbxOxiXmTRTvjdAxTtpfHHqQkTDAdwN4AwhRJkfMiSF3V1WSN6W51als7KbOVEFCFL9qFZsAdQAMtrnBCV+z7BxtPi5fm9Uiy0zZuaikiF21ZKZRj3IZcgufs0B/AtANoCviWgxET3vkxy2iC0IVhrEoK6USHRmja3AAoAVxeY56uFy9kYAZk6ftShKYDCzetbrnePqCCBIBTxJfBkBCCE6Jn4quFgtd5FLI50us06F56QJKEio35VuH4ZEu6qtfXDQTiYVZmxATsZnYe+KVocvYMlnmiCsAko5rA6XIwuM30NtXSzsAE5UWYLYQwpiuhtJZOYYZu29Bfbwew4gdt7IaAe1Gn+ScUbKb86uH7wylCysAGyQxBSAo4XWSZSesqnD6hKZvALU/qvfFUQFYLQpztT7Bo2jB3MATtrE44qMy6a7uA1XFspsYDf12YAVgA2SKZRBG2orVKkj7mDKZ5eqIM8BGGB3EtjudwZNQaqn0ho847XI6bgKiBWAAyQ2iVST7HJEtxpoM2cAmQ4rQBXE6Dx+vzFe4pjkajHXX/BoGagnu7VNzgEoz2vdC2D5MgMrAA8QUZPAwSwpVtbuW9n34DfVnxXMdE8GJ00Rfo8AYoufuTkA55ZUm1oGmn5FiBWAHawuA3U0brf2Acj/O9EQBGojmPx/IEcASaa1YQNoeQ7ARvxpMgIIM6wAPCBA7aEusU7h04UgTwInqyg1Pynd5gAcnOg2isvUTmA5cTWXgTojiuewAnCAxCYR5zSAWwWtqkoOP732gQVbAST5vlH7b30fgJ343UtTLybvI+U348QlgEUoaVgBeIAdF3F6uDWHoCgpM6aAhDufA6QBnFRsTpNsuXDSt0LgFGSKbUwM6txeIlgB2MHiGuIg2cT1qHJ0sjR43xvI+pm0CSj+o+x+Z9CSx8lVaabiM3UWkPq0i5J4CysAD3CyuLhVH9J10q36KIjgfZiTI8NYrH5t0EYA1SdBeDAHYDIfDOcjnBHFc1gBOEI69AjM28oT7nsIUHIE+ThoI7uz136VTe0Al6lfy/0jxFRPam7OAdgMO0jlO1l8OQwu1WlQOwvXDmqHEYV5mDp3C/4wrIvxC3KBGanhhOb1awdg+bZSdGuRjXW7DqvX/zKqh6b3Ir1C+7eLeupWzJcnFGFjyRFDER8a3RNN6q3FGRpej14cX4R35mxCXsPaqKwSOLl906j79wzviq551U5phnTLxSUntca/F2wFAFzYu2XiNHKJ167tj3fnbkFeg9p46rI+OFxekfglANm1s6IciWiGfU1/XP3qPACSlyqzXH1qAV77uTjKEch953VF59xstGxUB1PnbkZeg9oAJA9aken9wAXdUSMzAws378eFvVvi0elrNOOwOuL5w7AuOF4h0LNVgyjvaVr88fzueGnWRrRtWtdU2HcP74qKKoFRfSRHLlcMzMc7czar968/vT2G94z2HXVp/zZYuq1UdXD0x5HdUNC0nm4cH9wY72EuEU9f1hcvzNyInq0a4tObB+HKl+fg0DH98qEkaYec+sjJroWSQ+Xq9wRsAGUaVgA2ICL87wXdAQBFBU0SPq90GH4/LN5b1xmdc9RG9+yu1a4Bx59SYEmmcQPb6t4b0i0XQ7oZv9+iYR08+pvemvfO6Z6LczTcFirEuuarmZWBf1zSW1UAD48pRD0Peo1adM1rgAcv7AEAagNkhpvO7IgzuzQ3fCby/mgN9556PHhhD1UmhevP6BB1X+HOc6LLzDWD2gEArjy5LfYcLo8L225D1LR+LTx2qXb+x9Ivv7ElL1XN6teK8jLXp3WjKAVw34j4wlm3ZlbUO1qe4FQ3po3qoFfrRqblUShoVk/1Tte7TSPMmzQUXf80Xff5yNHxQ6N64oa3FmBY91xDL2BBh01AHiActEMH0ZadiBQUOSUwPkqCcRrFjBjE027twgrAA6oPWmMYd0mFMpaqDagyApDqc2p+QyysADygelejz4L4RLqdMBoUvNglmwp49a2kKgD3HDx5DSsADzCzpI1hnCAVTYR28Xo1TuRx0OmyEogVgAe4ucY+FSp8CoiYkjh5FEQq4vTIOlE4yhxAlZsbODyGFQDDpCPp3/57PrLOjJgDMHNcdSrACsADvNjUwjAAUqLhd9p84lm94jkAxg7V55qkeGmxSUg/23UM0zV9rBS6eP2J1ctA0wdWAB4geBko4xFhLGNOfXMic46yDFQIwZPAjHl4GWhIP9xljNI1VdfaW8HrU3bVSWA2ATFW4GWgjFeE0czo1TdT1Eaw9IAVgAd4fbZ50Ajrd7uOQbqmi4nCCO/nAOIngVMdVgAewHMAjFekgrJ1uvl0bA4gQUBRG8HSxMTmqwIgot8TkSCiZn7K4T7h1gAh/WxfSY/myRivO+LqKqDIOYAUL92+KQAiagNgGIDNiZ5NdcI6B5AKvdFURtshTAjx6KMzeA7AUZ4AcDdC0FnJkLsObjSImQGu8TUypeJllMGKUmRl4QyZsmuvIPuhdjqrrbizVDyf2Ume6mWg6VNuffHSQUSjAGwTQixJNINPRBMBTASA/Px812T648hu6N6ygSthv33dQHy0cBua1qvpSHi/P6czTu3YFJ8u3o6bzuzoSJhu8PFNp2L68p2qItBiTL9WWL69FHef64/HsFRGq+a88z9SWWuiUdYmjeiGnq0aui9YAkb3bYWl20pRKysDoy046YmlQ049XDe4HcadrO8MKZZXrx6A9+dvQevGdeLuRabnQ6N7onWj6GcuH5CPdbsP4/YhnVCnZibGDcxXPZbZ4YELuqNj8/q233cCcqunQETfAMjTuDUJwP0AhgkhSomoGECREGJPojCLiorE/PnznRWUYSJ4+ItVeGHGRtwzvKvq6azg3mkAgOLJI+OeN7rnNoeOnUDhg1+hXs1MrPjLcM/jTzcqKqvQcdIXAJzNTz/LiAIRLRBCFMVed20EIIQYqiNIIYB2AJTef2sAC4logBBip1vyMEy6EcY1/4yzeG4CEkIsA6A6U7UyAmAYhnGLMCpU3gfAMAwTUnyZBI5ECFHgtwwMwzBhhEcADMMwIYUVAMMwDMK5iY4VAMMwTEhhBcAwDBNSWAEwDMOEFFYADMMwSP1zfezACoBhGCaksAJgGIYJKawAGIZhwEdBMAzDMCGCFQDDMExIYQXAMBFkyd7bMlLAGqCIWCOLqzFjD98Pg2OYIHHjmR1xpLwS408pUK9NHlOI1o3raj7/8oQilB494ZF00dSrlYU7h3bGiEItv0tMUHjskt6aHtqCgGsewdyAPYIxDOMmQfDe5QZ6HsF47MgwDBNSWAEwDMOEFFYADMMwIYUVAMMwTEhhBcAwDBNSWAEwDMOEFFYADMMwIYUVAMMwTEhhBcAwDBNSWAEwDMOEFFYADMMwIYUVAMMwTEhhBcAwDBNSfFMARHQrEa0mohVE9KhfcjAMw4QVX/wBENFZAEYB6C2EKCei5n7IwTAME2b8GgHcCGCyEKIcAIQQu32Sg2EYJrT4pQA6AziNiOYQ0Qwi6q/3IBFNJKL5RDS/pKTEQxEZhgkbfzq/O6bfcZrfYniGayYgIvoGgJavuklyvE0AnAygP4D3iai90HBPJoSYAmAKIHkEc0tehmGY3w5u57cInuKaAhBCDNW7R0Q3AvhIbvDnElEVgGYAuIvPMAzjEX6ZgD4BcBYAEFFnADUB7PFJFoZhmFDiyyogAK8AeIWIlgM4DmCClvmHYRiGcQ9fFIAQ4jiAK/2Im2EYhpHgncAMwzAhhRUAwzBMSGEFwDAME1JYATAMw4QUSqXFN0RUAmCTzdebIZhLTVkua7Bc1giqXEBwZUtHudoKIXJiL6aUAkgGIpovhCjyW45YWC5rsFzWCKpcQHBlC5NcbAJiGIYJKawAGIZhQkqYFMAUvwXQgeWyBstljaDKBQRXttDIFZo5AIZhGCaaMI0AGIZhmAhYATAMw4SUUCgAIhpORGuIaD0R3ethvG2I6HsiWklEK4jodvn6g0S0jYgWy/9GRLxznyznGiI612X5iolomSzDfPlaEyL6mojWyf83lq8TET0ty7aUiPq5JFOXiHRZTEQHiegOP9KMiF4hot3yqbXKNcvpQ0QT5OfXEdEEl+T6BxGtluP+mIgaydcLiOhoRLo9H/HOSXL+r5dlJxfkspxvTtdXHbnei5CpmIgWy9e9TC+99sG7MiaESOt/ADIBbADQHpLfgSUAunsUdwsA/eS/swGsBdAdwIMA/qDxfHdZvloA2slyZ7ooXzGAZjHXHgVwr/z3vQAekf8eAeALAATJk9scj/JuJ4C2fqQZgNMB9AOw3G76QPJ8t1H+v7H8d2MX5BoGIEv++5EIuQoin4sJZ64sK8myn+eCXJbyzY36qiVXzP3HAPyvD+ml1z54VsbCMAIYAGC9EGKjkI6hfhfAKC8iFkLsEEIslP8+BGAVgFYGr4wC8K4QolwI8SuA9ZDk95JRAF6X/34dwOiI628IidkAGhFRC5dlGQJggxDCaPe3a2kmhJgJYJ9GfFbS51wAXwsh9gkh9gP4GsBwp+USQnwlhKiQf84G0NooDFm2BkKI2UJqRd6I+BbH5DJAL98cr69Gcsm9+EsBTDUKw6X00msfPCtjYVAArQBsifi9FcaNsCsQUQGAvgDmyJdukYdxryhDPHgvqwDwFREtIKKJ8rVcIcQO+e+dAHJ9kg0ALkN0xQxCmllNHz/S7VpIPUWFdkS0iIhmEJHi8byVLIsXclnJN6/T6zQAu4QQ6yKueZ5eMe2DZ2UsDArAd4ioPoAPAdwhhDgI4P8AdADQB8AOSENQPxgshOgH4DwANxPR6ZE35Z6OL+uEiagmgAsB/Fu+FJQ0U/EzffQgokkAKgC8LV/aASBfCNEXwO8AvENEDTwUKXD5FsPliO5keJ5eGu2DittlLAwKYBuANhG/W8vXPIGIakDK3LeFEB8BgBBilxCiUghRBeBFVJssPJVVCLFN/n83gI9lOXYpph35/91+yAZJKS0UQuySZQxEmsF6+ngmHxFdDeB8AOPkhgOyiWWv/PcCSPb1zrIMkWYiV+SykW9eplcWgDEA3ouQ19P00mof4GEZC4MCmAegExG1k3uVlwH4zIuIZfviywBWCSEej7geaTu/CICyOuEzAJcRUS0iagegE6SJJzdkq0dE2crfkCYRl8syKKsIJgD4NEK28fJKhJMBlEYMU90gqmcWhDSLiM9K+nwJYBgRNZbNH8Pka45CRMMB3A3gQiFEWcT1HCLKlP9uDyl9NsqyHSSik+VyOj7iW5yUy2q+eVlfhwJYLYRQTTteppde+wAvy1gys9ip8g/S7PlaSNp8kofxDoY0fFsKYLH8bwSANwEsk69/BqBFxDuTZDnXIMlVBglkaw9phcUSACuUdAHQFMC3ANYB+AZAE/k6AXhWlm0ZgCIXZasHYC+AhhHXPE8zSApoB4ATkOyqv7WTPpBs8uvlf9e4JNd6SHZgpZw9Lz97sZy/iwEsBHBBRDhFkBrkDQD+BflkAIflspxvTtdXLbnk668BuCHmWS/TS6998KyM8VEQDMMwISUMJiCGYRhGA1YADMMwIYUVAMMwTEhhBcAwDBNSWAEwDMOEFFYATCggokqKPmXU8JRJIrqBiMY7EG8xETWz8d65RPRnkk6G/CLxGwxjnSy/BWAYjzgqhOhj9mEhxPOJn3KV0wB8L///o8+yMGkKjwCYUCP30B8l6Zz3uUTUUb7+IBH9Qf77NpLObF9KRO/K15oQ0SfytdlE1Eu+3pSIviLpfPeXIG3eUeK6Uo5jMRG9oOw4jZFnLEln098G4ElIxydcQ0Se7F5nwgUrACYs1IkxAY2NuFcqhCiEtLvzSY137wXQVwjRC8AN8rU/A1gkX7sf0vHAAPAAgB+FED0gna+UDwBE1A3AWACD5JFIJYBxsREJId6DdCrkclmmZXLcF9r/dIbRhk1ATFgwMgFNjfj/CY37SwG8TUSfAPhEvjYY0rEBEEJ8J/f8G0ByPjJGvj6NiPbLzw8BcBKAedIRMKiD6kO+YukMyakHANQT0lnxDOM4rAAYJvq4Xa2zUUZCatgvADCJiAptxEEAXhdC3Gf4kOSasxmALCJaCaCFbBK6VQgxy0a8DKMLm4AYRjLNKP//EnmDiDIAtBFCfA/gHgANAdQHMAuyCYeIzgSwR0hnuc8EcIV8/TxILvoA6XCv3xBRc/leEyJqGyuIEKIIwDRI3p8ehXQYWh9u/Bk34BEAExbqyD1phelCCGUpaGMiWgqgHNIx1JFkAniLiBpC6sU/LYQ4QEQPAnhFfq8M1cf3/hnAVCJaAeBnAJsBQAixkoj+CMkDWwakkylvBqDl7rIfpEngmwA8rnGfYRyBTwNlQg0RFUM6VneP37IwjNewCYhhGCak8AiAYRgmpPAIgGEYJqSwAmAYhgkprAAYhmFCCisAhmGYkMIKgGEYJqT8P6LxWSjWj8nQAAAAAElFTkSuQmCC\n"
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "def dqn(n_episodes=2000, max_t=1000, eps_start=1.0, eps_end=0.01, eps_decay=0.995):\n",
     "    \"\"\"Deep Q-Learning.\n",
@@ -326,7 +251,7 @@
     "        print('\\rEpisode {}\\tAverage Score: {:.2f}'.format(i_episode, np.mean(scores_window)), end=\"\")\n",
     "        if i_episode % 100 == 0:\n",
     "            print('\\rEpisode {}\\tAverage Score: {:.2f}'.format(i_episode, np.mean(scores_window)))\n",
-    "        if np.mean(scores_window)>=15.0:\n",
+    "        if np.mean(scores_window)>=13.0:\n",
     "            print('\\nEnvironment solved in {:d} episodes!\\tAverage Score: {:.2f}'.format(i_episode-100, np.mean(scores_window)))\n",
     "            torch.save(agent.qnetwork_local.state_dict(), 'checkpoint.pth')\n",
     "            break\n",
@@ -351,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "outputs": [],
    "source": [
     "env.close()"

--- a/Banana_Navigation-Deep_Q_Networks/agent.py
+++ b/Banana_Navigation-Deep_Q_Networks/agent.py
@@ -1,6 +1,6 @@
 import numpy as np
 import random
-from collections import deque, namedtuple
+from collections import deque, namedtuple, defaultdict
 
 from model import QNetwork, DuellingQNetwork
 
@@ -15,7 +15,7 @@ class Agent():
     """Interacts with and learns from the environment."""
 
     def __init__(self, state_size, action_size, fc1_units, fc2_units, buffer_size, batch_size, alpha, gamma, tau,
-                 local_update_every, target_update_every, seed, a=1, b=1, dbl_dqn=False, priority_rpl=False, duel_dqn=False):
+                 local_update_every, target_update_every, seed, a, b, b_increase, b_end, dbl_dqn=False, priority_rpl=False, duel_dqn=False):
         """Initialize an Agent object.
 
         Params
@@ -40,6 +40,8 @@ class Agent():
         self.buffer_size = buffer_size                  # Size of memory buffer
         self.a = a                                      # Sampling probability (0=random | 1=priority)
         self.b = b                                      # Influence of importance sampling weights over learning
+        self.b_increase = b_increase                    #
+        self.b_end = b_end                              #
 
         # Agent modifications
         self.dbl_dqn = dbl_dqn                          # Double Q Learning
@@ -69,14 +71,14 @@ class Agent():
         if self.t_step % self.local_update_every == 0:
             # If enough samples are available in memory, get random subset and learn
             if len(self.memory) > self.batch_size:
-                experiences = self.memory.sample()
+                experiences = self.memory.sample(a=self.a)
                 self.learn(experiences, self.gamma)
         if self.t_step % self.target_update_every == 0:
             self.soft_update(self.qnetwork_local, self.qnetwork_target, self.tau)
 
         #Update eps and b
+        self.b = np.min([self.b_end, self.b + self.b_increase])
         #self.eps = max(self.eps_end, self.eps_decay*self.eps)
-        #self.b = 1-self.eps
 
     def act(self, state, eps=0.):
         """Returns actions for given state as per current policy.
@@ -106,7 +108,7 @@ class Agent():
             experiences (Tuple[torch.Variable]): tuple of (s, a, r, s', done) tuples
             gamma (float): discount factor
         """
-        states, actions, rewards, next_states, dones = experiences
+        states, actions, rewards, next_states, dones, indices = experiences
 
         # Get max predicted Q values (for next states) from target model
         if self.dbl_dqn:
@@ -121,16 +123,16 @@ class Agent():
 
         # Get expected Q values from local model
         Q_expected = self.qnetwork_local(states).gather(1, actions)
-    #PROBLEM HERE?
+
         # Compute loss
-#        if self.priority_rpl:
-#            errors = abs(Q_expected - Q_targets)
-#            self.memory.update_priorities(indices, errors)
-#            importance = [self.memory.importance[idx] for idx in indices]
-#            importance = np.array(importance)**self.b
-#            loss = torch.mean(torch.mul(errors.float(), torch.from_numpy(importance).float().to(device)))
-#        else:
-        loss = F.mse_loss(Q_expected, Q_targets)
+        if self.priority_rpl:
+            errors = abs(Q_expected - Q_targets)
+            self.memory.update_priorities(indices, errors)
+            importance = self.memory.get_importance(indices, self.a, self.b)
+            importance = np.array(importance)
+            loss = torch.mean(torch.mul(errors.float(), torch.from_numpy(importance).float().to(device)))
+        else:
+            loss = F.mse_loss(Q_expected, Q_targets)
 
         # Minimize the loss
         self.optimizer.zero_grad()
@@ -168,7 +170,6 @@ class ReplayBuffer:
         self.action_size = action_size
         self.memory = deque(maxlen=int(buffer_size))
         self.priorities = deque(maxlen=int(buffer_size))
-        self.importance = deque(maxlen=int(buffer_size))
         self.batch_size = batch_size
         self.experience = namedtuple("Experience", field_names=["state", "action", "reward", "next_state", "done"])
         self.seed = random.seed(seed)
@@ -185,16 +186,20 @@ class ReplayBuffer:
             probabilities = (np.array(self.priorities) ** a) / sum(np.array(self.priorities) ** a)
         return probabilities
 
+    def get_importance(self, experiences_idx, a, b):
+        """Gets the importance sampling weights associated with the experience index"""
+        importance = 1/len(self.memory) * 1/self.get_probs(a)               # Calculate our importance sampling weight    might need to use get_probs[i] for i in ...
+        importance = importance ** b
+        importance_norm = importance / max(importance)
+        importance_norm = [importance_norm[idx] for idx in experiences_idx]
+        return importance_norm
+
     def sample(self, a=1):
         """Randomly sample a batch of experiences from memory."""
         if self.is_priority:
             probabilities = self.get_probs(a)
             experiences_idx = np.random.choice(len(self.memory), size=min(len(self.memory),self.batch_size), p=probabilities)
             experiences = [self.memory[idx] for idx in experiences_idx]
-            importance = 1/len(self.memory) * 1/probabilities               # Calculate our importance sampling weight
-            importance_norm = importance / max(importance)
-            for idx, imp in zip(experiences_idx, importance_norm):
-                self.importance[idx] = imp
         else:
             experiences_idx = np.random.choice(len(self.memory), size=min(len(self.memory),self.batch_size))
             experiences = [self.memory[idx] for idx in experiences_idx]
@@ -205,11 +210,12 @@ class ReplayBuffer:
         next_states = torch.from_numpy(np.vstack([e.next_state for e in experiences if e is not None])).float().to(device)
         dones = torch.from_numpy(np.vstack([e.done for e in experiences if e is not None]).astype(np.uint8)).float().to(device)
 
-        return states, actions, rewards, next_states, dones
+        return states, actions, rewards, next_states, dones, experiences_idx
 
     def update_priorities(self, indices, errors):
-        for idx, err in zip(indices, errors):
-            self.priorities[idx] = abs(err) + 0.001
+        with torch.no_grad():
+            for idx, err in zip(indices, errors):
+                self.priorities[idx] = (abs(err) + 0.001)
 
     def __len__(self):
         """Return the current size of internal memory."""

--- a/Banana_Navigation-Deep_Q_Networks/model.py
+++ b/Banana_Navigation-Deep_Q_Networks/model.py
@@ -47,23 +47,21 @@ class DuellingQNetwork(nn.Module):
         self.seed = torch.manual_seed(seed)
         self.action_size = action_size
 
+        # Common initial layers
+        self.fc1 = nn.Linear(state_size, fc1_units)
+        self.fc2 = nn.Linear(fc1_units, fc2_units)
+
         # State value stream
-        self.fc1_val = nn.Linear(state_size, fc1_units)
-        self.fc2_val = nn.Linear(fc1_units, fc2_units)
         self.fc3_val = nn.Linear(fc2_units, 1)
 
         # Action advantage stream
-        self.fc1_adv = nn.Linear(state_size, fc1_units)
-        self.fc2_adv = nn.Linear(fc1_units, fc2_units)
         self.fc3_adv = nn.Linear(fc2_units, action_size)
 
     def forward(self, state):
         """Build a network that maps state -> action values."""
-        val = F.relu(self.fc1_val(state))
-        val = F.relu(self.fc2_val(val))
-        val = self.fc3_val(val)
-        adv = F.relu(self.fc1_adv(state))
-        adv = F.relu(self.fc2_adv(adv))
-        adv = self.fc3_adv(adv)
+        x = F.relu(self.fc1(state))
+        x = F.relu(self.fc2(x))
+        val = self.fc3_val(x)
+        adv = self.fc3_adv(x)
         x = val + (adv - adv.mean())
         return x

--- a/Taxi-TD_Methods/README.md
+++ b/Taxi-TD_Methods/README.md
@@ -36,7 +36,7 @@ The results of the interactions are recorded in `monitor.py`, which returns two 
 ### Licence
 #### MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2021 Colm Dowling
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
 files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,


### PR DESCRIPTION
## What?
I've attempted to fix some of the bugs in the original Banana Navigation - Deep Q Network script. 
## Why?
The previous script was encountering fatal errors. Most of the issues were in the priority replay code.
## How?
I've removed the sampling weights deque and created a function to calculate the weights from the priorities during each learning step. I've also fixed a few errors in the sampling function that were causing the script to crash.
## Testing?
These changes allow the agent to run quickly for vanilla, doubleDQN and duellingQN. The agent learns in all of these situations. The agent will also run when prioritised replay is enabled but is quite slow.
## Anything Else?
It would be worth looking at SumTrees for the prioritised replay implementation. This may reduce the time it takes to run.
